### PR TITLE
When lo is detected, tcp checksums will be incorrect as they are expe…

### DIFF
--- a/jobs/snort/templates/bin/ctl
+++ b/jobs/snort/templates/bin/ctl
@@ -27,10 +27,17 @@ case $1 in
 
     echo $$ > $PIDFILE
 
+    if [ "${COMPONENT}" == "lo" ]; then
+      CHKSUM="none"
+    else
+      CHKSUM="all"
+    fi
+
     exec /var/vcap/packages/snort/bin/snort \
       -c /var/vcap/packages/snort/etc/snort.conf \
       -i ${COMPONENT} \
       -l ${LOG_DIR} \
+      -k ${CHKSUM} \
       >>${LOG_DIR}/${output_label}.log 2>&1
 
     ;;


### PR DESCRIPTION
…cted to be calculated by the network card offloaded tcp stack, but skipped across local transit