### PR TITLE
Force install SSLeay

### DIFF
--- a/ci/docker/pulledpork/Dockerfile
+++ b/ci/docker/pulledpork/Dockerfile
@@ -3,7 +3,8 @@ FROM perl:latest
 WORKDIR /opt
 
 RUN curl -L http://cpanmin.us | perl - App::cpanminus
-RUN cpanm LWP::UserAgent Crypt::SSLeay
+RUN cpanm LWP::UserAgent
+RUN cpanm --force Crypt::SSLeay
 
 RUN wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pulledpork/pulledpork-0.7.0.tar.gz
 RUN tar xf pulledpork-0.7.0.tar.gz


### PR DESCRIPTION
Turns out, this isn't even really used, reading through the pulledpork.pl script. It's just imported.
Same conclusion as https://github.com/shirkdog/pulledpork/issues/258

So just force install SSLeay for now until we can get a patch in upstream.