### PR TITLE
don't use the same resource as an input and an output

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,7 +50,6 @@ jobs:
     trigger: true
   - get: snort-release-source
   - get: snort-blobs-yml
-    trigger: true
   - get: final-builds-dir-tarball
   - get: releases-dir-tarball
   - task: pulledpork


### PR DESCRIPTION
we're currently using snort-blobs-yml as an input and output for this pipeline. Since we're relying on an s3 version id for versioning, every time we push the snort-blobs-yml, we kick create a new version, run the build, and push snort-blobs-yml.

This cycle is only broken when we poll pulledpork enough that they start sending us 429: Too Many Requests